### PR TITLE
Add KhanCard autofill on showAnswer or failure

### DIFF
--- a/src/components/shared/Dropdown.tsx
+++ b/src/components/shared/Dropdown.tsx
@@ -1,5 +1,6 @@
-//import { useState } from 'react';
+import { useEffect, useContext } from 'react';
 import DropDownSelect from './DropDownSelect';
+import AutofillContext from '../../context/AutofillContext';
 import { options_array } from '../../types';
 import { useLocalStorage } from '../useLocalStorage';
 
@@ -14,10 +15,20 @@ interface DropdownProps {
 }
 
 function Dropdown(props: DropdownProps): JSX.Element {
+  const { tries, showAnswer } = useContext(AutofillContext);
   const [selectedValue, setSelectedValue] = useLocalStorage<string>(
     props.name + '-dropdown',
     ''
   );
+
+  useEffect(() => {
+    if (tries === 0 || showAnswer) {
+      setSelectedValue(props.answer);
+    } else if (!showAnswer) {
+      setSelectedValue('');
+    }
+  }, [tries, showAnswer]);
+
   const handleChange = (selectedOption: any) => {
     const chosenAnswer = selectedOption.value;
     if (props.correct_answer === undefined) {

--- a/src/components/shared/Dropdown.tsx
+++ b/src/components/shared/Dropdown.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useContext } from 'react';
 import DropDownSelect from './DropDownSelect';
-import AutofillContext from '../../context/AutofillContext';
 import { KhanCardContext } from './KhanCard'; // Import the context
+import AutofillContext from '../../context/AutofillContext';
 import { options_array } from '../../types';
 import { useLocalStorage } from '../useLocalStorage';
 
@@ -31,7 +31,7 @@ function Dropdown(props: DropdownProps): JSX.Element {
   }, [tries, showAnswer]);
 
   const { correctAnswers, setCorrectAnswers } = useContext(KhanCardContext)!; // Consume the context
-      
+
   const handleChange = (selectedOption: any) => {
     const chosenAnswer = selectedOption.value;
 

--- a/src/components/shared/Dropdown.tsx
+++ b/src/components/shared/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext } from 'react';
+import { useEffect, useContext, useRef } from 'react';
 import DropDownSelect from './DropDownSelect';
 import { KhanCardContext } from './KhanCard'; // Import the context
 import AutofillContext from '../../context/AutofillContext';
@@ -16,19 +16,31 @@ interface DropdownProps {
 }
 
 function Dropdown(props: DropdownProps): JSX.Element {
-  const { tries, showAnswer } = useContext(AutofillContext);
+  const { tries, showAnswer, setShowAnswer } = useContext(AutofillContext);
   const [selectedValue, setSelectedValue] = useLocalStorage<string>(
     props.name + '-dropdown',
     ''
   );
 
+  function usePrevious(prevValue: boolean) {
+    const ref = useRef<boolean | null>(null);
+    useEffect(() => {
+      ref.current = prevValue;
+    }, [prevValue]);
+    return ref.current;
+  }
+
+  const prevShowAnswer = usePrevious(showAnswer);
+
   useEffect(() => {
     if (tries === 0 || showAnswer) {
       setSelectedValue(props.answer);
-    } else if (!showAnswer) {
+      setShowAnswer(true);
+    } else if (prevShowAnswer && !showAnswer) {
+      // Show Answer went from True to False
       setSelectedValue('');
     }
-  }, [tries, showAnswer]);
+  }, [tries, showAnswer, prevShowAnswer]);
 
   const { correctAnswers, setCorrectAnswers } = useContext(KhanCardContext)!; // Consume the context
 

--- a/src/components/shared/ExpandBox.tsx
+++ b/src/components/shared/ExpandBox.tsx
@@ -1,7 +1,7 @@
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { useState } from 'react';
 import '../../styles/ExpandBox.scss';
+import { useLocalStorage } from '../useLocalStorage';
 
 interface ExpandBoxProps {
   class: string;
@@ -11,7 +11,10 @@ interface ExpandBoxProps {
 }
 
 function ExpandBox(props: ExpandBoxProps): JSX.Element {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useLocalStorage(
+    props.class + props.title + '-expandBox',
+    false
+  );
   function toggle() {
     setOpen((prev) => !prev);
   }

--- a/src/components/shared/KhanCard.tsx
+++ b/src/components/shared/KhanCard.tsx
@@ -63,6 +63,7 @@ function KhanCard(props: KhanCardProps): JSX.Element {
     () => ({
       tries,
       showAnswer,
+      setShowAnswer,
     }),
     [tries, showAnswer]
   );
@@ -146,8 +147,16 @@ function KhanCard(props: KhanCardProps): JSX.Element {
         <br></br>
         <div className="khan-horizontal-line"></div>
         <div className="khan-footer">
-          <button className="show-answer" onClick={handleShowAnswer}>
-            {showAnswer ? 'Hide Answer' : 'Show Answer'}
+          <button
+            className="show-answer"
+            onClick={handleShowAnswer}
+            style={{ cursor: tries === 0 ? 'default' : 'pointer' }}
+          >
+            {showAnswer
+              ? tries === 0
+                ? 'The Answer'
+                : 'Hide Answer'
+              : 'Show Answer'}
           </button>
           <div className="tries-left-container">
             <div className="tries-left">Tries Left</div>

--- a/src/components/shared/KhanCard.tsx
+++ b/src/components/shared/KhanCard.tsx
@@ -55,7 +55,7 @@ function KhanCard(props: KhanCardProps): JSX.Element {
     false
   );
   const [correctAnswers, setCorrectAnswers] = useLocalStorage<
-  (boolean | null | number)[]
+    (boolean | null | number)[]
   >(props.name + '-correct_answers', props.correct_answer);
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
 
@@ -166,7 +166,9 @@ function KhanCard(props: KhanCardProps): JSX.Element {
               className="khan-check-button"
               onClick={handleClick}
               disabled={
-                isButtonDisabled || tries === 0 || showAnswer || correct ? true : false
+                isButtonDisabled || tries === 0 || showAnswer || correct
+                  ? true
+                  : false
               }
             >
               {isExploding && <ConfettiExplosion {...smallProps} />}

--- a/src/components/shared/KhanCard.tsx
+++ b/src/components/shared/KhanCard.tsx
@@ -1,6 +1,7 @@
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import ConfettiExplosion from 'react-confetti-explosion';
+import AutofillContext from '../../context/AutofillContext';
 import { useLocalStorage } from '../useLocalStorage';
 
 interface KhanCardProps {
@@ -34,10 +35,21 @@ const smallProps: ConfettiProps = {
 
 function KhanCard(props: KhanCardProps): JSX.Element {
   const [isExploding, setIsExploding] = useState(false);
-  const [tries, setTries] = useState(3);
+  const [tries, setTries] = useLocalStorage(props.name + '-tries', 3);
   const [correct, setCorrect] = useLocalStorage(props.name + '-correct', false);
-  const [expand, setExpand] = useState(false);
-  const [showAnswer, setShowAnswer] = useState(false);
+  const [expand, setExpand] = useLocalStorage(props.name + '-expand', false);
+  const [showAnswer, setShowAnswer] = useLocalStorage(
+    props.name + '-showAnswer',
+    false
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      tries,
+      showAnswer,
+    }),
+    [tries, showAnswer]
+  );
 
   const handleClick = () => {
     if (tries <= 0) {
@@ -100,7 +112,9 @@ function KhanCard(props: KhanCardProps): JSX.Element {
         )}
         &nbsp;&nbsp; Fill in the Blank
       </div>
-      <div className="khan-content">{props.children}</div>
+      <AutofillContext.Provider value={contextValue}>
+        <div className="khan-content">{props.children}</div>
+      </AutofillContext.Provider>
       <br></br>
       <div className="khan-horizontal-line"></div>
       <div className="khan-footer">
@@ -123,7 +137,7 @@ function KhanCard(props: KhanCardProps): JSX.Element {
           <button
             className="khan-check-button"
             onClick={handleClick}
-            disabled={tries == 0 || correct ? true : false}
+            disabled={tries === 0 || showAnswer || correct ? true : false}
           >
             {isExploding && <ConfettiExplosion {...smallProps} />}
             Check
@@ -140,7 +154,7 @@ function KhanCard(props: KhanCardProps): JSX.Element {
             <p className="incorrect-explanation">{`Incorrect. ${props.incorrect}`}</p>
           ))}
       </div>
-      <div>{(showAnswer || tries == 0) && <p>{props.correct}</p>}</div>
+      <div>{(tries === 0 || showAnswer) && <p>{props.correct}</p>}</div>
     </div>
   );
 }

--- a/src/components/shared/KhanInput.tsx
+++ b/src/components/shared/KhanInput.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useContext } from 'react';
+import AutofillContext from '../../context/AutofillContext';
 import { useLocalStorage } from '../useLocalStorage';
 
 interface KhanInputProps {
@@ -10,7 +12,17 @@ interface KhanInputProps {
 }
 
 function KhanInput(props: KhanInputProps): JSX.Element {
+  const { tries, showAnswer } = useContext(AutofillContext);
   const [value, setValue] = useLocalStorage(props.name + '-input', '');
+
+  useEffect(() => {
+    if (tries === 0 || showAnswer) {
+      setValue(props.answer);
+    } else if (!showAnswer) {
+      setValue('');
+    }
+  }, [tries, showAnswer]);
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const strippedAnswer = e.target.value.replace(/\s/g, '');
     const lowerCaseAnswer = strippedAnswer.toLowerCase();

--- a/src/components/shared/KhanInput.tsx
+++ b/src/components/shared/KhanInput.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext } from 'react';
 import { KhanCardContext } from './KhanCard'; // Import the context
-import { useLocalStorage } from '../useLocalStorage';
 import AutofillContext from '../../context/AutofillContext';
+import { useLocalStorage } from '../useLocalStorage';
 
 interface KhanInputProps {
   size: string;
@@ -26,7 +26,7 @@ function KhanInput(props: KhanInputProps): JSX.Element {
       setValue('');
     }
   }, [tries, showAnswer]);
-  
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const strippedAnswer2 = e.target.value.trim();
     const strippedAnswer = e.target.value.replace(/\s/g, '');

--- a/src/components/shared/KhanInput.tsx
+++ b/src/components/shared/KhanInput.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from 'react';
+import React, { useEffect, useContext, useRef } from 'react';
 import { KhanCardContext } from './KhanCard'; // Import the context
 import AutofillContext from '../../context/AutofillContext';
 import { useLocalStorage } from '../useLocalStorage';
@@ -15,17 +15,29 @@ interface KhanInputProps {
 }
 
 function KhanInput(props: KhanInputProps): JSX.Element {
-  const { tries, showAnswer } = useContext(AutofillContext);
+  const { tries, showAnswer, setShowAnswer } = useContext(AutofillContext);
   const [value, setValue] = useLocalStorage(props.name + '-input', '');
   const { correctAnswers, setCorrectAnswers } = useContext(KhanCardContext)!; // Consume the context
+
+  function usePrevious(prevValue: boolean) {
+    const ref = useRef<boolean | null>(null);
+    useEffect(() => {
+      ref.current = prevValue;
+    }, [prevValue]);
+    return ref.current;
+  }
+
+  const prevShowAnswer = usePrevious(showAnswer);
 
   useEffect(() => {
     if (tries === 0 || showAnswer) {
       setValue(props.answer);
-    } else if (!showAnswer) {
+      setShowAnswer(true);
+    } else if (prevShowAnswer && !showAnswer) {
+      // Show Answer went from True to False
       setValue('');
     }
-  }, [tries, showAnswer]);
+  }, [tries, showAnswer, prevShowAnswer]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const strippedAnswer2 = e.target.value.trim();

--- a/src/context/AutofillContext.ts
+++ b/src/context/AutofillContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+const AutofillContext = createContext({
+  tries: 3,
+  showAnswer: false,
+});
+
+export default AutofillContext;

--- a/src/context/AutofillContext.ts
+++ b/src/context/AutofillContext.ts
@@ -1,8 +1,15 @@
 import { createContext } from 'react';
 
-const AutofillContext = createContext({
+interface AutofillContextType {
+  tries: number;
+  showAnswer: boolean;
+  setShowAnswer: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const AutofillContext = createContext<AutofillContextType>({
   tries: 3,
   showAnswer: false,
+  setShowAnswer: () => {},
 });
 
 export default AutofillContext;


### PR DESCRIPTION
## Summary

Closes #262 
Closes #267 

Added local storage to many KhanCard state variables along with autofill capabilities either when the user wants to see the answer or they run out of tries.